### PR TITLE
rename imports in import fxmanifest.lua

### DIFF
--- a/fxmanifest.lua
+++ b/fxmanifest.lua
@@ -6,7 +6,7 @@ version '1.0.0'
 
 shared_scripts {
   '@ox_lib/init.lua',
-  '@qbx_core/imports.lua',
+  '@qbx_core/import.lua',
   'config.lua'
 }
 


### PR DESCRIPTION
'@qbx_core/import.lua'

## Description

Fix error for core import misspell

## Checklist

<!-- Put an x inside the [ ] to check an item, like so: [x] -->

- [ ] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [x] My code fits the style guidelines.
- [x] My PR fits the contribution guidelines.
