### PR TITLE
fix: play the sound & notification only if onRadio

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -27,18 +27,19 @@ local function connectToRadio(channel)
 end
 
 local function leaveradio()
-    qbx.playAudio({
-        audioName = 'End_Squelch',
-        audioRef = 'CB_RADIO_SFX',
-        source = cache.ped
-    })
+    if onRadio then
+        qbx.playAudio({
+            audioName = 'End_Squelch',
+            audioRef = 'CB_RADIO_SFX',
+            source = cache.ped
+        })
+        exports.qbx_core:Notify(locale('left_channel'), 'error')
+    end
     radioChannel = 0
     onRadio = false
     exports['pma-voice']:setRadioChannel(0)
     exports['pma-voice']:setVoiceProperty('radioEnabled', false)
-    exports.qbx_core:Notify(locale('left_channel'), 'error')
 end
-
 
 local function toggleRadio(toggle)
     radioMenu = toggle


### PR DESCRIPTION
## Description
Don't play the sound & don't notify when you didn't even have a radio duh

## Checklist

<!-- Put an x inside the [ ] to check an item, like so: [x] -->

- [x] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [x] My pull request fits the contribution guidelines & code conventions.
