### PR TITLE
fix(client/server): Radio Object Creation

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -11,6 +11,5 @@
     "new_channel": "New channel: ",
     "clicksOn": "Mic clicks are now on",
     "clicksOff": "Mic clicks are now off",
-    "failed_spawn": "Failed to spawn radioprop",
-    "failed_get_control": "Failed to gain control of radio prop"
+    "failed_spawn": "Failed to spawn radioprop"
 }

--- a/locales/pl.json
+++ b/locales/pl.json
@@ -11,6 +11,5 @@
     "new_channel": "Nowy kanał: ",
     "clicksOn": "Kliknięcia mikrofonu są teraz włączone",
     "clicksOff": "Kliknięcia mikrofonu są teraz wyłączone",
-    "failed_spawn": "Nie udało się stworzyć obiektu radia",
-    "failed_get_control": "Nie udało się uzyskać kontroli nad obiektem radia"
+    "failed_spawn": "Nie udało się stworzyć obiektu radia"
 }

--- a/server/main.lua
+++ b/server/main.lua
@@ -2,8 +2,6 @@ lib.versionCheck('Qbox-project/qbx_radio')
 
 local config = require 'config.shared'
 local restrictedChannels = config.restrictedChannels
-local playerRadios = {}
-
 
 exports.qbx_core:CreateUseableItem('radio', function(source)
     TriggerClientEvent('qbx_radio:client:use', source)
@@ -24,57 +22,8 @@ for channel, jobs in pairs(restrictedChannels) do
     end)
 end
 
----@param source number
-local function deleteProp(source)
-    local prop = playerRadios[source]
-
-    if prop then
-        if DoesEntityExist(prop) then
-            DeleteEntity(prop)
-        end
-
-        playerRadios[source] = nil
-    end
-end
-
----@param source number
----@return number?
-lib.callback.register('qbx_radio:server:spawnProp', function(source)
-    local ped = GetPlayerPed(source)
-    local coords = GetEntityCoords(ped)
-    local object = CreateObject(`prop_cs_hand_radio`, coords.x, coords.y, coords.z, true, false, false)
-
-    lib.waitFor(function()
-        if DoesEntityExist(object) then
-            return true
-        end
-    end, locale('failed_spawn'), 2000)
-
-    playerRadios[source] = object
-
-    local netId = NetworkGetNetworkIdFromEntity(object)
-
-    SetEntityIgnoreRequestControlFilter(object, true)
-
-    return netId
-end)
-
-AddEventHandler('playerDropped', function()
+RegisterNetEvent('qbx_radio:server:setHoldingRadio', function(bool)
     local src = source
-
-    deleteProp(src)
-end)
-
-AddEventHandler('onResourceStop', function(resource)
-    if resource ~= cache.resource then return end
-
-    for i in pairs (playerRadios) do
-        deleteProp(i)
-    end
-end)
-
-RegisterNetEvent('qbx_radio:server:deleteProp', function()
-    local src = source
-
-    deleteProp(src)
+    if type(bool) ~= 'boolean' then return end
+    Player(src).state.isHoldingRadio = bool
 end)


### PR DESCRIPTION
## Description

Now uses locally spawned client objects synced with state bags. Instead of fully server sided objects

Closes #42
Supersedes #43 

Tested with CL2 and all fine also 
![Screenshot 2025-03-06 074409](https://github.com/user-attachments/assets/174a3350-d27c-4fc7-9270-bad96981aee7)

<!-- What does your pull request change? Why should it be merged? Does it fix an issue? -->

## Checklist

<!-- Put an x inside the [ ] to check an item, like so: [x] -->

- [x] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [x] My pull request fits the contribution guidelines & code conventions.
